### PR TITLE
feat(Add): Wide view mode, Showing journal queries on today journal page

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import fileHierarchy from "./pageHierarchyList.css?inline";
 import CSSside from './side.css?inline';
 import CSSbottom from './bottom.css?inline';
 import CSSwide from './wide.css?inline';
+import CSSwideJournalQueries from './wideJournalQueries.css?inline';
 import { displayToc } from "./toc";
 import { CSSpageSupportContentPosition } from "./toc";
 const keyModifyHierarchyList = "th-modifyHierarchy";
@@ -15,6 +16,7 @@ const keySide = "th-side";
 const keyBottom = "th-bottom";
 const keyWide = "th-wide";
 const keyPageSupportContentPosition = "th-pageSupportContentPosition";
+const keyWideJournalQueries = "th-wideJournalQueries";
 let checkOnBlockChanged: boolean = false;//一度飲み
 let processBlockChanged: boolean = false;//処理中
 
@@ -55,6 +57,7 @@ const main = () => {
         case "wide view":
             logseq.provideStyle({ key: keyWide, style: CSSwide });
             logseq.provideStyle({ key: keyPageSupportContentPosition, style: CSSpageSupportContentPosition(logseq.settings) });
+            if (logseq.settings!.booleanWideModeJournalQueries === true) logseq.provideStyle({ key: keyWideJournalQueries, style: CSSwideJournalQueries });
             break;
     }
     if (logseq.settings!.placeSelect !== "unset") {
@@ -124,6 +127,7 @@ const main = () => {
                     removeProvideStyle(keySide);
                     removeProvideStyle(keyWide);
                     removeProvideStyle(keyPageSupportContentPosition);
+                    removeProvideStyle(keyWideJournalQueries);
                     logseq.provideStyle({ key: keyBottom, style: CSSbottom });
                     break;
                 case "side":
@@ -144,6 +148,7 @@ const main = () => {
                         removeProvideStyle(keyBottom);
                         logseq.provideStyle({ key: keyWide, style: CSSwide });
                         logseq.provideStyle({ key: keyPageSupportContentPosition, style: CSSpageSupportContentPosition(logseq.settings) });
+                        if (newSet.booleanWideModeJournalQueries === true) logseq.provideStyle({ key: keyWideJournalQueries, style: CSSwideJournalQueries });
                     } else {
                         logseq.UI.showMsg("Wide view mode is available from Logseq v0.9.11");
                         setTimeout(() => { logseq.updateSettings({ placeSelect: oldSet.placeSelect }) }, 300);
@@ -154,6 +159,7 @@ const main = () => {
                     removeProvideStyle(keyBottom);
                     removeProvideStyle(keyWide);
                     removeProvideStyle(keyPageSupportContentPosition);
+                    removeProvideStyle(keyWideJournalQueries);
                     break;
             }
         } else {
@@ -180,15 +186,20 @@ const main = () => {
             else if (oldSet.booleanTableOfContents === true && newSet.booleanTableOfContents === false) removeElementClass("th-toc");
 
             //positionのCSSを変更
-            if (newSet.placeSelect === "wide view"
-                && (oldSet.enumScheduleDeadline !== newSet.enumScheduleDeadline
+            if (newSet.placeSelect === "wide view") {
+                if (oldSet.enumScheduleDeadline !== newSet.enumScheduleDeadline
                     || oldSet.enumTableOfContents !== newSet.enumTableOfContents
                     || oldSet.enumLinkedReferences !== newSet.enumLinkedReferences
                     || oldSet.enumUnlinkedReferences !== newSet.enumUnlinkedReferences
                     || oldSet.enumPageHierarchy !== newSet.enumPageHierarchy
-                    || oldSet.enumPageTags !== newSet.enumPageTags)) {
-                removeProvideStyle(keyPageSupportContentPosition);
-                logseq.provideStyle({ key: keyPageSupportContentPosition, style: CSSpageSupportContentPosition(newSet) });
+                    || oldSet.enumPageTags !== newSet.enumPageTags) {
+                    removeProvideStyle(keyPageSupportContentPosition);
+                    logseq.provideStyle({ key: keyPageSupportContentPosition, style: CSSpageSupportContentPosition(newSet) });
+                }
+                if (oldSet.booleanWideModeJournalQueries === false && newSet.booleanWideModeJournalQueries === true)
+                    logseq.provideStyle({ key: keyWideJournalQueries, style: CSSwideJournalQueries });
+                else if (oldSet.booleanWideModeJournalQueries === true && newSet.booleanWideModeJournalQueries === false)
+                    removeProvideStyle(keyWideJournalQueries);
             }
         }
     });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -51,6 +51,13 @@ export const settingsTemplate = (defaultMode: string): SettingSchemaDesc[] => [
         default: false,
         description: "default: false",
     },
+    {//wide viewモード、Journal Queriesを表示するかどうか
+        key: "booleanWideModeJournalQueries",
+        title: "Showing journal queries on today journal page (wide view only)",
+        type: "boolean",
+        default: false,
+        description: "default: false *When on the single journal page.",
+    },
     {//wide viewモード、横の並び順 SCHEDULED AND DEADLINEの位置
         key: "enumScheduleDeadline",
         title: "Scheduled and deadline position (wide view only)",
@@ -98,6 +105,6 @@ export const settingsTemplate = (defaultMode: string): SettingSchemaDesc[] => [
         enumChoices: ["1", "2", "3", "4", "5","6"],
         default: "6",
         description: "default: 6 *It is not displayed only when necessary",
-    }
+    },
 ];
 

--- a/src/wide.css
+++ b/src/wide.css
@@ -5,7 +5,7 @@ div#root div#main-content-container:not(:has(div#journals)) div.page.relative>di
 div#root div#right-sidebar div.page.relative>div.relative{min-width:94%}
 div#root div.page.relative>div:not(.relative){padding:1em;height:fit-content;position:sticky;top:1em}
 div#root div.page.relative>div:not(.relative):not(:has(div.hidden)){flex:.3;max-width:fit-content}
-div#root div.page.relative>div:not(.relative):has(div.hidden){writing-mode:vertical-rl;max-width:3.2em}
+div#root div.page.relative>div:not(.relative):not(#today-queries):has(div.hidden){writing-mode:vertical-rl;max-width:3.2em}
 div#root div.page.relative>div:not(.relative):is(.page-tags,.page-hierarchy) div.initial{font-size:.9em}
 div#root div.page.relative>div:is(.page-tags,.page-hierarchy){padding:1em}
 div#root div.page.relative>div.page-hierarchy:not(:has(div.hidden)){max-width:580px;min-width:400px}

--- a/src/wideJournalQueries.css
+++ b/src/wideJournalQueries.css
@@ -1,0 +1,7 @@
+div#root div:is(#main-content-container,#right-sidebar) div.is-journals div#today-queries {
+  max-height: 88vh;
+  overflow: scroll;
+  min-width: 500px;
+  max-width: 500px;
+  display: unset
+}


### PR DESCRIPTION
プラグインの設定項目に追加
トグルはデフォルトでオフ

今日のシングルジャーナルページを開いたときに、ジャーナルクエリーが用意されているが、表示しないようにしていた
そこで、設定でトグルできるようにした

左右の配置の入れ替えには組み込んでいない。
また、タイトルがついてなくてトグルもできないため、ジャーナルのとなりに固定表示になっている。